### PR TITLE
OPS-0 fix broken changes in github 2.9

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -231,7 +231,8 @@ resource "aws_lb_listener_rule" "redirect_http_to_https" {
 ## Github ipranges
 
 provider "github" {
-  anonymous = true
+  version    = "<=2.8.1"
+  anonymous  = true
 	individual = true
 }
 


### PR DESCRIPTION
New provider version is breaking our tests in atlantis module.
It still works with 2.8.1