### PR TITLE
OPS-3841 Adding option to specify the fargate platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ $ cd terraform-aws-atlantis
 ### Run Atlantis as a Terraform module
 
 This way allows integration with your existing Terraform configurations.
- 
+
 ```hcl
 module "atlantis" {
   source  = "terraform-aws-modules/atlantis/aws"
@@ -153,6 +153,7 @@ If all provided subnets are public (no NAT gateway) then `ecs_service_assign_pub
 | ecs\_service\_deployment\_maximum\_percent | The upper limit (as a percentage of the service's desiredCount) of the number of running tasks that can be running in a service during a deployment | number | `"200"` | no |
 | ecs\_service\_deployment\_minimum\_healthy\_percent | The lower limit (as a percentage of the service's desiredCount) of the number of running tasks that must remain running and healthy in a service during a deployment | number | `"50"` | no |
 | ecs\_service\_desired\_count | The number of instances of the task definition to place and keep running | number | `"1"` | no |
+| ecs\_service\_platform\_version | AWS Fargate platform versions, when specifying a platform version, you can use either a specific version number, for example 1.4.0, or LATEST (which uses the 1.3.0 platform version) | string | `"LATEST"` | no |
 | ecs\_task\_cpu | The number of cpu units used by the task | number | `"256"` | no |
 | ecs\_task\_memory | The amount (in MiB) of memory used by the task | number | `"512"` | no |
 | name | Name to use on all resources created (VPC, ALB, etc) | string | `"atlantis"` | no |

--- a/main.tf
+++ b/main.tf
@@ -528,6 +528,7 @@ resource "aws_ecs_service" "atlantis" {
   )}"
   desired_count                      = var.ecs_service_desired_count
   launch_type                        = "FARGATE"
+  platform_version                   = var.ecs_service_platform_version
   deployment_maximum_percent         = var.ecs_service_deployment_maximum_percent
   deployment_minimum_healthy_percent = var.ecs_service_deployment_minimum_healthy_percent
 

--- a/variables.tf
+++ b/variables.tf
@@ -161,6 +161,12 @@ variable "ecs_service_desired_count" {
   default     = 1
 }
 
+variable "ecs_service_platform_version" {
+  description = "AWS Fargate platform versions, when specifying a platform version, you can use either a specific version number, for example 1.4.0, or LATEST (which uses the 1.3.0 platform version)"
+  type        = string
+  default     = "LATEST"
+}
+
 variable "ecs_service_deployment_maximum_percent" {
   description = "The upper limit (as a percentage of the service's desiredCount) of the number of running tasks that can be running in a service during a deployment"
   type        = number


### PR DESCRIPTION
Adding parameter to specify which platform version to use for fargate, also defining a variable with a default to ensure at least one platform version specified, by default its latest which at the moment means 1.3.0