### PR TITLE
OPS-3896 Update listener rule

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -224,9 +224,9 @@ resource "aws_lb_listener_rule" "redirect_http_to_https" {
   }
 
   condition {
-    field  = "path-pattern"
-    values = ["*"]
-  }
+    path_pattern {
+      values = ["*"]
+    }
 }
 ## Github ipranges
 


### PR DESCRIPTION
- Due to AWS provider upgrade the listener rule condition got deprecated: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-3-upgrade#resource-aws_lb_listener_rule