### PR TITLE
Attach Security Groups to ALB by name

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ If all provided subnets are public (no NAT gateway) then `ecs_service_assign_pub
 | public\_subnets | A list of public subnets inside the VPC | list(string) | `[]` | no |
 | route53\_zone\_name | Route53 zone name to create ACM certificate in and main A-record, without trailing dot | string | `""` | no |
 | security\_group\_ids | List of one or more security groups to be added to the load balancer | list(string) | `[]` | no |
+| security\_group\_names | List of one or more security groups to be added to the load balancer | list(string) | `[]` | no |
 | ssm\_kms\_key\_arn | ARN of KMS key to use for entryption and decryption of SSM Parameters. Required only if your key uses a custom KMS key and not the default key | string | `""` | no |
 | tags | A map of tags to use on all resources | map(string) | `{}` | no |
 | vpc\_id | ID of an existing VPC where resources will be created | string | `""` | no |

--- a/data.tf
+++ b/data.tf
@@ -1,0 +1,14 @@
+data "aws_security_groups" "alb" {
+  count = length(var.security_group_names) >= 1 ? 1 : 0
+  dynamic "filter" {
+    for_each = var.security_group_names
+    content {
+      name   = "group-name"
+      values = [filter.value]
+    }
+  }
+  filter {
+    name   = "vpc-id"
+    values = [local.vpc_id]
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -171,7 +171,12 @@ module "alb" {
 
   vpc_id          = local.vpc_id
   subnets         = local.public_subnet_ids
-  security_groups = flatten([module.alb_https_sg.this_security_group_id, module.alb_http_sg.this_security_group_id, var.security_group_ids])
+  security_groups = flatten([
+    module.alb_https_sg.this_security_group_id,
+    module.alb_http_sg.this_security_group_id,
+    var.security_group_ids,
+    data.aws_security_groups.alb[*].ids,
+  ])
 
   logging_enabled     = var.alb_logging_enabled
   log_bucket_name     = var.alb_log_bucket_name

--- a/variables.tf
+++ b/variables.tf
@@ -57,7 +57,7 @@ variable "private_subnets" {
 variable "alb_ingress_cidr_blocks" {
   description = "List of IPv4 CIDR ranges to use on all ingress rules of the ALB."
   type        = list(string)
-  default     = ["0.0.0.0/0"]
+  default     = []
 }
 
 variable "alb_log_bucket_name" {
@@ -303,6 +303,12 @@ variable "custom_environment_variables" {
 }
 
 variable "security_group_ids" {
+  description = "List of one or more security groups to be added to the load balancer"
+  type        = list(string)
+  default     = []
+}
+
+variable "security_group_names" {
   description = "List of one or more security groups to be added to the load balancer"
   type        = list(string)
   default     = []


### PR DESCRIPTION
## Description
Looks up one or more security groups for being attached to the ALB.

## Motivation and Context
In order to avoid hardcoding SG IDs.

## Breaking Changes
N/A
Staged for being released as `fl1.1.4`

## How Has This Been Tested?
Used local copy of the module in the `ops-infra-maze` repo.